### PR TITLE
Refactor use contexts

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,21 +19,11 @@ import { Screen, AppState, NotebookState, GlobalSettings, BoxType, BoxState } fr
 import { createNewUntypedLambdaBoxFromSource, defaultSettings } from './untyped-lambda-integration/AppTypes'
 import { UntypedLambdaState, UntypedLambdaSettings, EvaluationStrategy, UntypedLambdaType } from './untyped-lambda-integration/Types'
 import { MacroTable } from '@lambdulus/core'
+import { Theme, ThemeContext } from './contexts/Theme'
 
 
-
-/**
- * This is the main Application
- * in the future - when building Exam Mode - I will need to replace some part of the application components
- * if it's only some component at the top, it can be done easily
- * if it's gonna replace some deeper stuff I will need to implement some Namespace FROM which app and integrations
- * will inport parts and this Namespace will take care of that
- */
-
-
-interface Props {}
-export default class App extends Component<Props, AppState> {
-  constructor (props : Props) {
+export default class App extends Component<{}, AppState> {
+  constructor (props : {}) {
     super(props)
 
     console.log(`VERSION: ${process.env.REACT_APP_VERSION_INFO}`)
@@ -47,7 +37,7 @@ export default class App extends Component<Props, AppState> {
     this.updateSettings = this.updateSettings.bind(this)
     this.importNotebook = this.importNotebook.bind(this)
     this.clearWorkspace = this.clearWorkspace.bind(this)
-    this.toggleDarkMode = this.toggleDarkMode.bind(this)
+    this.toggleTheme = this.toggleTheme.bind(this)
 
     this.createNotebookFromURL = this.createNotebookFromURL.bind(this)
   }
@@ -132,41 +122,46 @@ export default class App extends Component<Props, AppState> {
 
   // NOTE: render is OK
   render () {
-    const { notebook, currentScreen, darkmode } = this.state
+    const { notebook, currentScreen, theme } = this.state
     const { settings } = notebook
 
+    const darkmode = theme === Theme.Dark
+
     return (
-      <div id='app' className={ darkmode ? 'dark' : 'light' }>
-        <div id="bad-screen-message">
-          Lambdulus only runs on screens at least 900 pixels wide.
+      <ThemeContext.Provider value={ theme }>
+        <div id='app' className={ darkmode ? 'dark' : 'light' }>
+          <div id="bad-screen-message">
+            Lambdulus only runs on screens at least 900 pixels wide.
+          </div>
+          <TopBar
+            state={ this.state }
+            onScreenChange={ this.setScreen }
+            onImport={ this.importNotebook }
+            onClearWorkspace={ this.clearWorkspace }
+            onDarkModeChange={ this.toggleTheme }
+          />
+
+
+          <MenuBar
+            state={ this.state }
+            onScreenChange={ this.setScreen }
+          />
+
+          { (() => {
+            switch (currentScreen) {
+              case Screen.MAIN:
+                return <Notebook state={ notebook } updateNotebook={ this.updateNotebook } settings={ settings } />
+
+              case Screen.HELP:
+                return <Help/>
+
+              case Screen.SETTINGS:
+                return <SettingsScreen settings={ settings } updateSettings={ this.updateSettings } />
+            }
+          })()}
         </div>
-        <TopBar
-          state={ this.state }
-          onScreenChange={ this.setScreen }
-          onImport={ this.importNotebook }
-          onClearWorkspace={ this.clearWorkspace }
-          onDarkModeChange={ this.toggleDarkMode }
-        />
 
-
-        <MenuBar
-          state={ this.state }
-          onScreenChange={ this.setScreen }
-        />
-
-        { (() => {
-          switch (currentScreen) {
-            case Screen.MAIN:
-              return <Notebook state={ notebook } updateNotebook={ this.updateNotebook } settings={ settings } darkmode={ darkmode } />
-
-            case Screen.HELP:
-              return <Help darkmode={ darkmode } />
-
-            case Screen.SETTINGS:
-              return <SettingsScreen settings={ settings } updateSettings={ this.updateSettings } />
-          }
-        })()}
-      </div>
+      </ThemeContext.Provider>
     )
   }
 
@@ -210,11 +205,12 @@ export default class App extends Component<Props, AppState> {
     }
   }
 
-  toggleDarkMode () : void {
-    const { darkmode } = this.state
+  toggleTheme () : void {
+    const { theme } = this.state
+    const opposite = theme === Theme.Dark ? Theme.Light : Theme.Dark
 
-    this.setState({ darkmode : ! darkmode })
-    updateAppStateToStorage({ ...this.state, darkmode : ! darkmode })
+    this.setState({ theme : opposite })
+    updateAppStateToStorage({ ...this.state, theme : opposite })
   }
 
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,6 +20,7 @@ import { createNewUntypedLambdaBoxFromSource, defaultSettings } from './untyped-
 import { UntypedLambdaState, UntypedLambdaSettings, EvaluationStrategy, UntypedLambdaType } from './untyped-lambda-integration/Types'
 import { MacroTable } from '@lambdulus/core'
 import { Theme, ThemeContext } from './contexts/Theme'
+import { SettingsContext } from './contexts/Settings'
 
 
 export default class App extends Component<{}, AppState> {
@@ -129,38 +130,41 @@ export default class App extends Component<{}, AppState> {
 
     return (
       <ThemeContext.Provider value={ theme }>
-        <div id='app' className={ darkmode ? 'dark' : 'light' }>
-          <div id="bad-screen-message">
-            Lambdulus only runs on screens at least 900 pixels wide.
+        <SettingsContext.Provider value={ settings }>
+
+          <div id='app' className={ darkmode ? 'dark' : 'light' }>
+            <div id="bad-screen-message">
+              Lambdulus only runs on screens at least 900 pixels wide.
+            </div>
+            <TopBar
+              state={ this.state }
+              onScreenChange={ this.setScreen }
+              onImport={ this.importNotebook }
+              onClearWorkspace={ this.clearWorkspace }
+              onDarkModeChange={ this.toggleTheme }
+            />
+
+
+            <MenuBar
+              state={ this.state }
+              onScreenChange={ this.setScreen }
+            />
+
+            { (() => {
+              switch (currentScreen) {
+                case Screen.MAIN:
+                  return <Notebook state={ notebook } updateNotebook={ this.updateNotebook } />
+
+                case Screen.HELP:
+                  return <Help/>
+
+                case Screen.SETTINGS:
+                  return <SettingsScreen updateSettings={ this.updateSettings } />
+              }
+            })()}
           </div>
-          <TopBar
-            state={ this.state }
-            onScreenChange={ this.setScreen }
-            onImport={ this.importNotebook }
-            onClearWorkspace={ this.clearWorkspace }
-            onDarkModeChange={ this.toggleTheme }
-          />
 
-
-          <MenuBar
-            state={ this.state }
-            onScreenChange={ this.setScreen }
-          />
-
-          { (() => {
-            switch (currentScreen) {
-              case Screen.MAIN:
-                return <Notebook state={ notebook } updateNotebook={ this.updateNotebook } settings={ settings } />
-
-              case Screen.HELP:
-                return <Help/>
-
-              case Screen.SETTINGS:
-                return <SettingsScreen settings={ settings } updateSettings={ this.updateSettings } />
-            }
-          })()}
-        </div>
-
+        </SettingsContext.Provider>
       </ThemeContext.Provider>
     )
   }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -48,7 +48,6 @@ export default class App extends Component<{}, AppState> {
   }
 
   // TODO: all of this needs to be moved to more apropriate component
-  // maybe something like Notebook or similar -- this just isn't right
 
   // I don't think it should get moved to the component, standalone helper function would be OK
   // OR -> split it --> there will be very simple top level abstraction implementation

--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -3,6 +3,7 @@ import { defaultSettings as UntypedLambdaDefaultSettings } from './untyped-lambd
 
 import { BoxType, Screen, AppState, GlobalSettings, NotebookState, BoxState } from "./Types"
 import { UntypedLambdaState } from './untyped-lambda-integration/Types'
+import { Theme } from './contexts/Theme'
 
 
 export const CLEAR_WORKSPACE_CONFIRMATION : string =
@@ -37,7 +38,7 @@ export const InitNotebookState : NotebookState = {
 export const EmptyAppState : AppState = {
   notebook : InitNotebookState,
   currentScreen : Screen.MAIN,
-  darkmode : false
+  theme : Theme.Light
 }
 
 

--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -24,11 +24,15 @@ export function mapBoxTypeToStr (type : BoxType) : string {
   }
 }
 
+export const DefaultSettings : GlobalSettings
+  = { [UNTYPED_CODE_NAME] : UntypedLambdaDefaultSettings }
+
+
 export const InitNotebookState : NotebookState = {
   boxList : [],
   activeBoxIndex : NaN,
   focusedBoxIndex : undefined,
-  settings : { [UNTYPED_CODE_NAME] : UntypedLambdaDefaultSettings, },
+  settings : DefaultSettings,
 
   menuOpen : false,
 

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -1,5 +1,6 @@
 import { UntypedLambdaState, UntypedLambdaSettings } from "./untyped-lambda-integration/Types"
 import { NoteState } from "./markdown-integration/AppTypes"
+import { Theme } from "./contexts/Theme"
 
 export enum BoxType {
   UNTYPED_LAMBDA = 'UNTYPED_LAMBDA',
@@ -58,5 +59,5 @@ export interface NotebookState {
 export interface AppState {
   notebook : NotebookState,
   currentScreen : Screen,
-  darkmode : boolean
+  theme : Theme
 }

--- a/src/components/Box.tsx
+++ b/src/components/Box.tsx
@@ -22,14 +22,13 @@ interface BoxProperties {
   state : BoxState
   isActive : boolean
   isFocused : boolean
-  darkmode : boolean
 
   updateBoxState (box : BoxState) : void
   addBoxAfter (box : BoxState) : void
 }
 
 export default function Box (props : BoxProperties) : JSX.Element {
-  const { state, isActive, isFocused, updateBoxState, addBoxAfter, darkmode } : BoxProperties = props
+  const { state, isActive, isFocused, updateBoxState, addBoxAfter } : BoxProperties = props
   const { type } = state
 
   // const macroTable = useContext(MacroTableContext)
@@ -42,8 +41,6 @@ export default function Box (props : BoxProperties) : JSX.Element {
         state={ state as UntypedLambdaState }
         isActive={ isActive }
         isFocused={ isFocused }
-        // macroTable={ macroTable }
-        darkmode={ darkmode }
         
         setBoxState={ updateBoxState }
         addBox={ addBoxAfter }
@@ -56,7 +53,6 @@ export default function Box (props : BoxProperties) : JSX.Element {
         state={ state as NoteState }
         isActive={ isActive }
         isFocused={ isFocused }
-        darkmode={ darkmode }
 
         setBoxState={ updateBoxState }
       />

--- a/src/components/BoxContainer.tsx
+++ b/src/components/BoxContainer.tsx
@@ -12,7 +12,6 @@ interface Props {
   isActiveBox : boolean
   isFocusedBox : boolean
   box : BoxState
-  darkmode : boolean
 
   makeActive : () => void
   onBlur : () => void
@@ -47,7 +46,6 @@ export class BoxContainer extends Component<Props, State> {
       addBoxBefore,
       addBoxAfter,
       removeBox,
-      darkmode
     } : Props = this.props
   
     const { modalOpen } = this.state
@@ -81,7 +79,6 @@ export class BoxContainer extends Component<Props, State> {
             isFocused={ isFocusedBox }
             updateBoxState={ updateBoxState }
             addBoxAfter={ addBoxAfter }
-            darkmode={ darkmode }
           />
         </div>
 

--- a/src/components/BoxContainer.tsx
+++ b/src/components/BoxContainer.tsx
@@ -2,7 +2,7 @@ import React, { MouseEvent, Component } from 'react'
 import { mapBoxTypeToStr } from '../Constants'
 import Box from './Box'
 import BoxTitleBar from './BoxTitleBar'
-import { BoxState, GlobalSettings } from '../Types'
+import { BoxState } from '../Types'
 
 import "../styles/BoxContainer.css"
 import PickBoxTypeModal from './PickBoxTypeModal'
@@ -19,7 +19,6 @@ interface Props {
   removeBox : () => void
   addBoxBefore : (state : BoxState) => void
   addBoxAfter : (state : BoxState) => void
-  settings : GlobalSettings
 }
 
 interface State {
@@ -70,7 +69,6 @@ export class BoxContainer extends Component<Props, State> {
             updateBoxState={ updateBoxState }
             addBoxBefore={ addBoxBefore }
             addBoxAfter={ addBoxAfter }
-            settings={ this.props.settings }
           />
           
           <Box
@@ -89,7 +87,6 @@ export class BoxContainer extends Component<Props, State> {
                 this.props.addBoxAfter(box)
                 this.setState({ modalOpen : false })
               } }
-              settings={ this.props.settings }
             />
           :
           <div className="add_box_after" onMouseDown={ () => this.setState({ modalOpen : true }) } >

--- a/src/components/BoxTitleBar.tsx
+++ b/src/components/BoxTitleBar.tsx
@@ -1,5 +1,5 @@
 import React, { Component, MouseEvent } from 'react'
-import { BoxType, BoxState, GlobalSettings } from '../Types'
+import { BoxType, BoxState } from '../Types'
 import UntypedLambdaBTB from '../untyped-lambda-integration/BoxTopBar'
 import { UntypedLambdaState } from '../untyped-lambda-integration/Types'
 
@@ -22,7 +22,6 @@ interface Props {
   updateBoxState : (box : BoxState) => void
   addBoxBefore : (box : BoxState) => void
   addBoxAfter : (box : BoxState) => void
-  settings : GlobalSettings
 }
 
 interface State {

--- a/src/components/CreateBox.tsx
+++ b/src/components/CreateBox.tsx
@@ -1,13 +1,12 @@
 import React, { Component } from 'react'
 
-import { BoxState, GlobalSettings } from '../Types'
+import { BoxState } from '../Types'
 
 import "../styles/CreateBox.css"
 import PickBoxTypeModal from './PickBoxTypeModal'
 
 interface Props {
   addNew : (box : BoxState) => void
-  settings : GlobalSettings
 }
 
 interface State {
@@ -45,7 +44,6 @@ export default class CreateBox extends Component <Props, State> {
             addNew(box)
             this.setState({ modalOpen : false })
           } }
-          settings={ this.props.settings }
         />
       )
     }

--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -1,6 +1,8 @@
 import React, { KeyboardEvent } from 'react'
 import MonacoEditor from 'react-monaco-editor'
 
+import { Theme, ThemeContext } from '../contexts/Theme'
+
 import '../styles/Editor.css'
 
 // import { EvaluationStrategy } from '../App'
@@ -20,7 +22,6 @@ interface EditorProperties {
   syntaxError : Error | null
   submitOnEnter : boolean
   shouldReplaceLambda : boolean
-  darkmode : boolean
   
   onContent (content : string) : void
   onShiftEnter () : void
@@ -37,7 +38,6 @@ export default function Editor (props : EditorProperties) : JSX.Element {
     syntaxError,
     submitOnEnter,
     shouldReplaceLambda,
-    darkmode,
 
     onContent,
     onEnter,
@@ -101,7 +101,6 @@ export default function Editor (props : EditorProperties) : JSX.Element {
         <InputField
           placeholder={ placeholder }
           content={ content }
-          darkmode={ darkmode }
           onContent={ (content : string) => onChange(content) }
           onKeyDown={ onKeyDown }
         />
@@ -113,14 +112,13 @@ export default function Editor (props : EditorProperties) : JSX.Element {
 interface InputProps {
   placeholder : string
   content : string
-  darkmode : boolean
   // onChange (event : ChangeEvent<HTMLTextAreaElement>) : void
   onContent (content : string) : void
   onKeyDown (event : KeyboardEvent<HTMLDivElement>) : void
 }
 
 function InputField (props : InputProps) : JSX.Element {
-  const { content, darkmode, onKeyDown, onContent } : InputProps = props
+  const { content, onKeyDown, onContent } : InputProps = props
   const lines : number = content.split('\n').length
 
 
@@ -128,25 +126,29 @@ function InputField (props : InputProps) : JSX.Element {
     <div
       onKeyDownCapture={ onKeyDown }
     >
-      <MonacoEditor
-        // width="800"
-        height={ Math.max(5 * 19 ,Math.min(40 * 19, (lines + 1) * 19)) } // 10 lines by default
-        language="markdown"
-        theme= { darkmode ? 'vs-dark' : 'vs-light' }
-        value={ content }
-        options={ {
-          formatOnPaste : true,
-          minimap : { enabled : false },
-          renderLineHighlight : "none",
-          scrollBeyondLastLine : false,
-          overviewRulerBorder : false,
-          scrollbar : {
-            // handleMouseWheel : false,
-          } } }
-        onChange={ (content : string) => onContent(content) }
-        // editorDidMount={ ::this.editorDidMount }
-        editorDidMount={ (editor, monaco) => editor.focus() }
-      />
+      <ThemeContext.Consumer>
+        { (theme : Theme) =>
+            <MonacoEditor
+              height={ Math.max(5 * 19 ,Math.min(40 * 19, (lines + 1) * 19)) } // 10 lines by default
+              language="markdown"
+              theme= { theme === Theme.Dark ? 'vs-dark' : 'vs-light' }
+              value={ content }
+              options={ {
+                formatOnPaste : true,
+                minimap : { enabled : false },
+                renderLineHighlight : "none",
+                scrollBeyondLastLine : false,
+                overviewRulerBorder : false,
+                scrollbar : {
+                  // handleMouseWheel : false,
+                } } }
+              onChange={ (content : string) => onContent(content) }
+              // editorDidMount={ ::this.editorDidMount }
+              editorDidMount={ (editor, _monaco) => editor.focus() }
+            />
+        }
+
+      </ThemeContext.Consumer>
     </div>
   )
 }

--- a/src/components/PickBoxTypeModal.tsx
+++ b/src/components/PickBoxTypeModal.tsx
@@ -1,40 +1,47 @@
 import React from 'react'
-import { GlobalSettings, BoxState } from '../Types'
+import { BoxState } from '../Types'
 import { createNewMarkdown } from '../markdown-integration/AppTypes'
 import { UntypedLambdaSettings, UntypedLambdaState } from '../untyped-lambda-integration/Types'
 import { createNewUntypedLambdaExpression, ADD_BOX_LABEL, CODE_NAME as UNTYPED_CODE_NAME } from '../untyped-lambda-integration/AppTypes'
 
 
 import '../styles/PickBoxTypeModal.css'
+import { SettingsContext } from '../contexts/Settings'
 
 
 interface Props {
   addNew (box : BoxState) : void
-  settings : GlobalSettings
 }
 
 
 export default function PickBoxTypeModal (props : Props) : JSX.Element {
-  const { addNew, settings } : Props = props
+  const { addNew } : Props = props
 
-  const untLSettings : UntypedLambdaSettings = settings[UNTYPED_CODE_NAME] as UntypedLambdaState
-
+  
   const addLambdaBox = (
-    <div className='add-box--group'
-      onClick={ (e) => {
-        e.stopPropagation()
-        // this.setState({ opened : false })
-        addNew(createNewUntypedLambdaExpression(untLSettings)) }
+    <SettingsContext.Consumer>
+      {
+        settings => {
+          const untLSettings : UntypedLambdaSettings = settings[UNTYPED_CODE_NAME] as UntypedLambdaState
+          
+          return  <div className='add-box--group'
+                    onClick={ (e) => {
+                      e.stopPropagation()
+                      // this.setState({ opened : false })
+                      addNew(createNewUntypedLambdaExpression(untLSettings)) }
+                    }
+                  >
+                    <div
+                      className='plusBtn'
+                      title='Create new λ box'
+                    >
+                      <p className='create-box--big'>λ</p>
+                      <p className='creat-box--label'>{ ADD_BOX_LABEL }</p>
+                    </div>
+                  </div>
+        }
       }
-    >
-      <div
-        className='plusBtn'
-        title='Create new λ box'
-      >
-        <p className='create-box--big'>λ</p>
-        <p className='creat-box--label'>{ ADD_BOX_LABEL }</p>
-      </div>
-    </div>
+    </SettingsContext.Consumer>
   )
 
   // const addLispBox = (

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -4,6 +4,7 @@ import { AppState, Screen, NotebookState } from '../Types'
 
 import '../styles/TopBar.css'
 import { decodeNotebook } from '../Constants'
+import { Theme } from '../contexts/Theme'
 
 
 interface Props {
@@ -16,7 +17,9 @@ interface Props {
 
 export default function TopBar (props : Props) : JSX.Element {
   const { state, onImport, onClearWorkspace, onScreenChange, onDarkModeChange } : Props = props
-  const { notebook : ntbk, currentScreen, darkmode } : AppState = state
+  const { notebook : ntbk, currentScreen, theme } : AppState = state
+
+  const darkmode : boolean = theme === Theme.Dark
 
   // const dehydrated : object = dehydrate(state)
 

--- a/src/contexts/Settings.ts
+++ b/src/contexts/Settings.ts
@@ -1,0 +1,6 @@
+import { createContext } from "react"
+
+import { DefaultSettings } from "../Constants"
+
+
+export const SettingsContext = createContext(DefaultSettings)

--- a/src/contexts/Theme.ts
+++ b/src/contexts/Theme.ts
@@ -1,0 +1,8 @@
+import { createContext } from "react"
+
+export enum Theme {
+  Light,
+  Dark,
+}
+
+export const ThemeContext = createContext(Theme.Light)

--- a/src/markdown-integration/Note.tsx
+++ b/src/markdown-integration/Note.tsx
@@ -12,7 +12,6 @@ export interface NoteProperties {
   state : NoteState
   isActive : boolean
   isFocused : boolean
-  darkmode : boolean
 
   setBoxState (state : NoteState) : void
 }
@@ -24,7 +23,6 @@ export default function Note (props : NoteProperties) : JSX.Element {
       editor : { placeholder, content, syntaxError },
       isEditing,
     },
-    darkmode,
     isActive,
     setBoxState,
   } = props
@@ -51,7 +49,6 @@ export default function Note (props : NoteProperties) : JSX.Element {
           syntaxError={ syntaxError } // data
           submitOnEnter={ false } // data
           shouldReplaceLambda={ false }
-          darkmode={ darkmode }
           
           onContent={ onContent } // fn
           onEnter={ () => void 0 } // fn

--- a/src/screens/Help.tsx
+++ b/src/screens/Help.tsx
@@ -4,7 +4,7 @@ import 'github-markdown-css/github-markdown-light.css'
 import guide from '../misc/UserGuide'
 import ReactMarkdown from'react-markdown'
 
-export default function Help (props : { darkmode : boolean }) : JSX.Element {
+export default function Help (props : {}) : JSX.Element {
   (window as any).guide = guide
   return (
   <div className='helpSpace'>

--- a/src/screens/Notebook.tsx
+++ b/src/screens/Notebook.tsx
@@ -13,7 +13,6 @@ import { BoxContainer } from '../components/BoxContainer'
 interface Props {
   state : NotebookState
   settings : GlobalSettings
-  darkmode : boolean
 
   updateNotebook (notebook : Partial<NotebookState>) : void
 }
@@ -38,7 +37,7 @@ export default class Notebook extends PureComponent<Props> {
   // }
 
   render () {
-    const { state, settings, darkmode } = this.props
+    const { state, settings } = this.props
     const { activeBoxIndex, focusedBoxIndex, boxList } = state
 
     return (
@@ -60,7 +59,6 @@ export default class Notebook extends PureComponent<Props> {
                 updateBoxState={ (box : BoxState) => this.updateBoxState(i, box) }
                 onBlur={ () => this.onBlur(i) }
                 settings={ settings }
-                darkmode={ darkmode }
               />
             </li>
           ) }

--- a/src/screens/Notebook.tsx
+++ b/src/screens/Notebook.tsx
@@ -5,14 +5,13 @@
 
 import React, { PureComponent } from 'react'
 import CreateBox from '../components/CreateBox'
-import { BoxType, NotebookState, GlobalSettings, BoxState } from '../Types'
+import { BoxType, NotebookState, BoxState } from '../Types'
 
 import { onMarkDownBlur, NoteState, onMarkDownActive } from '../markdown-integration/AppTypes'
 import { BoxContainer } from '../components/BoxContainer'
 
 interface Props {
   state : NotebookState
-  settings : GlobalSettings
 
   updateNotebook (notebook : Partial<NotebookState>) : void
 }
@@ -37,7 +36,7 @@ export default class Notebook extends PureComponent<Props> {
   // }
 
   render () {
-    const { state, settings } = this.props
+    const { state } = this.props
     const { activeBoxIndex, focusedBoxIndex, boxList } = state
 
     return (
@@ -58,7 +57,6 @@ export default class Notebook extends PureComponent<Props> {
                 removeBox={ () => this.removeBox(i) }
                 updateBoxState={ (box : BoxState) => this.updateBoxState(i, box) }
                 onBlur={ () => this.onBlur(i) }
-                settings={ settings }
               />
             </li>
           ) }
@@ -68,7 +66,6 @@ export default class Notebook extends PureComponent<Props> {
               <div className='top-level--create-box'>
                 <CreateBox
                   addNew={ (box : BoxState) => this.insertBefore(state.boxList.length, box) }
-                  settings={ settings }
                 />
               </div>
             :

--- a/src/screens/Settings.tsx
+++ b/src/screens/Settings.tsx
@@ -7,31 +7,37 @@ import {
 } from '../untyped-lambda-integration/AppTypes'
 import { GlobalSettings } from '../Types'
 import { UntypedLambdaSettings } from '../untyped-lambda-integration/Types'
+import { SettingsContext } from '../contexts/Settings'
 
 
 interface Props {
-  settings : GlobalSettings
   updateSettings : (settings : GlobalSettings) => void
 }
 
 export default function SettingsScreen (props : Props) : JSX.Element {
-  const { settings, updateSettings } = props
-
-  const untypedSettings : UntypedLambdaSettings = settings[UNTYPED_CODE_NAME] as UntypedLambdaSettings
+  const { updateSettings } = props
 
   return (
-    <div className='settingsSpace'>
-      <h2>
-        Settings for Untyped Lambda Calculus:
-      </h2>
-      <UntypedLambdaCalculusSet
-        settings={ untypedSettings }
-        settingsEnabled={ UNTYPED_GLOBAL_SETTINGS_ENABLER }
-        change={
-          (unTypLSet : UntypedLambdaSettings) =>
-            updateSettings({ ...settings, [UNTYPED_CODE_NAME] : unTypLSet })
+    <SettingsContext.Consumer>
+      {
+        settings => {
+          const untypedSettings : UntypedLambdaSettings = settings[UNTYPED_CODE_NAME] as UntypedLambdaSettings
+          
+          return  <div className='settingsSpace'>
+                    <h2>
+                      Settings for Untyped Lambda Calculus:
+                    </h2>
+                    <UntypedLambdaCalculusSet
+                      settings={ untypedSettings }
+                      settingsEnabled={ UNTYPED_GLOBAL_SETTINGS_ENABLER }
+                      change={
+                        (unTypLSet : UntypedLambdaSettings) =>
+                          updateSettings({ ...settings, [UNTYPED_CODE_NAME] : unTypLSet })
+                      }
+                    />
+                  </div>
         }
-      />
-    </div>
+      }
+    </SettingsContext.Consumer>
   )
 }

--- a/src/untyped-lambda-integration/EmptyExpression.tsx
+++ b/src/untyped-lambda-integration/EmptyExpression.tsx
@@ -15,7 +15,6 @@ interface EmptyExpressionProps {
     content : string
     syntaxError : Error | null
   }
-  darkmode : boolean
 
   onContent (content : string) : void
   onDebug () : void
@@ -25,7 +24,7 @@ interface EmptyExpressionProps {
 
 
 export default function EmptyExpression(props : EmptyExpressionProps) : JSX.Element{
-  const { className, isActive, editor, isMinimized, darkmode /*, state  */ } = props
+  const { className, isActive, editor, isMinimized } = props
   const {
     placeholder,
     content,
@@ -55,7 +54,6 @@ export default function EmptyExpression(props : EmptyExpressionProps) : JSX.Elem
                 syntaxError={ syntaxError } // data
                 submitOnEnter={ false } // data
                 shouldReplaceLambda={ true }
-                darkmode={ darkmode }
 
                 onContent={ props.onContent } // fn
                 onEnter={ () => void 0 } // fn

--- a/src/untyped-lambda-integration/ExerciseBox.tsx
+++ b/src/untyped-lambda-integration/ExerciseBox.tsx
@@ -27,7 +27,6 @@ export interface EvaluationProperties {
   state : UntypedLambdaExpressionState
   isActive : boolean
   isFocused : boolean
-  darkmode : boolean
 
   setBoxState (state : UntypedLambdaExpressionState) : void
   addBox (box : UntypedLambdaState) : void
@@ -53,7 +52,7 @@ export default class ExerciseBox extends PureComponent<EvaluationProperties> {
   }
 
   render () : JSX.Element {
-    const { state, isActive, addBox, darkmode } : EvaluationProperties = this.props
+    const { state, isActive, addBox } : EvaluationProperties = this.props
     const {
       minimized,
       history,
@@ -93,7 +92,6 @@ export default class ExerciseBox extends PureComponent<EvaluationProperties> {
         editor={ editor }
         isNormalForm={ isNormalForm }
         shouldShowDebugControls={ isActive }
-        darkmode={ darkmode }
 
         createBoxFrom={ this.createBoxFrom }
         setBoxState={ this.props.setBoxState }

--- a/src/untyped-lambda-integration/Expression.tsx
+++ b/src/untyped-lambda-integration/Expression.tsx
@@ -20,7 +20,6 @@ interface EvaluatorProps {
   }
   isNormalForm : boolean
   isExercise : boolean
-  darkmode : boolean
 
   createBoxFrom (stepRecord : StepRecord) : UntypedLambdaState
   setBoxState (state : UntypedLambdaExpressionState) : void
@@ -39,7 +38,7 @@ export default class Expression extends PureComponent<EvaluatorProps> {
   }
 
   render () : JSX.Element {
-    const { className, state, editor, shouldShowDebugControls, isExercise, darkmode } = this.props
+    const { className, state, editor, shouldShowDebugControls, isExercise } = this.props
 
     const { isRunning, SDE, macrotable } : UntypedLambdaExpressionState = state
 
@@ -115,7 +114,6 @@ export default class Expression extends PureComponent<EvaluatorProps> {
                 content={ content } // data
                 syntaxError={ syntaxError } // data
                 submitOnEnter={ true } // data
-                darkmode={ darkmode }
 
                 onContent={ this.props.onContent } // fn
                 onEnter={ this.props.onEnter } // fn // tohle asi bude potreba

--- a/src/untyped-lambda-integration/ExpressionBox.tsx
+++ b/src/untyped-lambda-integration/ExpressionBox.tsx
@@ -29,7 +29,6 @@ export interface EvaluationProperties {
   state : UntypedLambdaExpressionState
   isActive : boolean
   isFocused : boolean
-  darkmode : boolean
 
   setBoxState (state : UntypedLambdaExpressionState) : void
   addBox (box : UntypedLambdaState) : void
@@ -51,7 +50,7 @@ export default class ExpressionBox extends PureComponent<EvaluationProperties> {
   }
 
   render () : JSX.Element {
-    const { state, isActive, addBox, darkmode } : EvaluationProperties = this.props
+    const { state, isActive, addBox } : EvaluationProperties = this.props
     const {
       minimized,
       history,
@@ -91,7 +90,6 @@ export default class ExpressionBox extends PureComponent<EvaluationProperties> {
         editor={ editor }
         isNormalForm={ isNormalForm }
         shouldShowDebugControls={ isActive }
-        darkmode={ darkmode }
 
         createBoxFrom={ this.createBoxFrom }
         setBoxState={ this.props.setBoxState }

--- a/src/untyped-lambda-integration/UntypedLambdaBox.tsx
+++ b/src/untyped-lambda-integration/UntypedLambdaBox.tsx
@@ -16,7 +16,6 @@ interface Props {
   state : UntypedLambdaState
   isActive : boolean
   isFocused : boolean
-  darkmode : boolean
 
   setBoxState (state : UntypedLambdaState) : void
   addBox (box : UntypedLambdaState) : void
@@ -24,7 +23,7 @@ interface Props {
 
 export default class UntypedLambdaBox extends PureComponent<Props> {
   render () {
-    const { state, isActive, isFocused, setBoxState, addBox, darkmode } : Props = this.props
+    const { state, isActive, isFocused, setBoxState, addBox } : Props = this.props
     const { settingsOpen, subtype, macrolistOpen, SLI, expandStandalones, strategy, SDE, editor, minimized } : UntypedLambdaState = state
 
 
@@ -48,7 +47,6 @@ export default class UntypedLambdaBox extends PureComponent<Props> {
                   }
                 })
               }
-              darkmode={ darkmode }
               onDebug={ () => this.onSubmitExpression(UntypedLambdaType.ORDINARY) }
               onExercise={ () => this.onSubmitExpression(UntypedLambdaType.EXERCISE) }
               setBoxState={ setBoxState }
@@ -63,7 +61,6 @@ export default class UntypedLambdaBox extends PureComponent<Props> {
               isFocused={ isFocused }
               setBoxState={ setBoxState }
               addBox={ addBox }
-              darkmode={ darkmode }
             />
           )
         
@@ -75,7 +72,6 @@ export default class UntypedLambdaBox extends PureComponent<Props> {
               isFocused={ isFocused }
               setBoxState={ setBoxState }
               addBox={ addBox }
-              darkmode={ darkmode }
             />
           )
       }


### PR DESCRIPTION
use React's Context API to disctribute some of the values that otherwise would go a long path through props to get to the target.